### PR TITLE
deps: drop cap-std dep; use cap-std-ext re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 camino = "1"
-cap-std = { version = "3", default-features = false, features = ["fs_utf8"] }
+cap-std-ext = "4"
 rustix = { version = "1", features = ["fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod raw;
 
 use anyhow::{Context, Result, bail};
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std::fs::Dir;
+use cap_std_ext::cap_std::fs::Dir;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
 use std::os::fd::AsRawFd;
@@ -263,8 +263,9 @@ mod tests {
     #[test]
     fn test_load_from_rootfs_dir() {
         let tmpdir = setup_test_rootfs();
-        let rootfs_dir = Dir::open_ambient_dir(tmpdir.path(), cap_std::ambient_authority())
-            .expect("failed to open rootfs dir");
+        let rootfs_dir =
+            Dir::open_ambient_dir(tmpdir.path(), cap_std_ext::cap_std::ambient_authority())
+                .expect("failed to open rootfs dir");
         let packages = load_from_rootfs_dir(&rootfs_dir).expect("failed to load packages");
 
         assert!(packages.contains_key("filesystem"));


### PR DESCRIPTION
Replace the direct cap-std v3 dependency with cap-std-ext v4 and use its re-export of cap_std. This matches chunkah.

Assisted-by: Claude Opus 4.5