### PR TITLE
lib: support `Clone` for `Package`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpm-qa"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "A thin Rust wrapper around `rpm -qa`"
 license = "LGPL-2.1-or-later"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct FileInfo {
 }
 
 /// Metadata for an installed RPM package.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Package {
     /// Package name.
     pub name: String,


### PR DESCRIPTION
Everything in there is `Clone` and this makes writing tests easier.